### PR TITLE
v1.0.1: 提供可选的token加密请求config

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -54,6 +54,7 @@ bot.send_group_msg(group_id, message)
 > | host | `127.0.0.1` | 接收数据上报的地址 |
 > | port | `8080` | 对应数据上报的端口 | 
 > | post_path | "" | 对应数据上报的终点名 |
+> | token | "" | 对应数据上报的token，用于加密信息 |
 
 ```
 {

--- a/src/cq_qq_api/constant.py
+++ b/src/cq_qq_api/constant.py
@@ -1,5 +1,6 @@
 DEFAULT_CONFIG = {
     "host": "127.0.0.1",
     "port": 8080,
-    "post_path": ""
+    "post_path": "",
+    "token": ""
 }

--- a/src/mcdreforged.plugin.json
+++ b/src/mcdreforged.plugin.json
@@ -1,6 +1,6 @@
 {
 	"id": "cq_qq_api",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"name": "cq_qq_api",
 	"description": {
 		"en_us": "Websocket application to process information from QQ",


### PR DESCRIPTION
根据 #1 中要求，config 文件添加 `token` 参数，用于加密通讯：

[提供可选的token加密请求config](https://github.com/XueK66/PF-cq_qq_api/commit/5dbd381d4c4df6571ee33bca184f8025ffb1c695)

感谢 [12skoko](https://github.com/12skoko) 提供的建议！